### PR TITLE
Bump dependency embedded-graphics to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["bitmap", "monochrome", "font", "monospace"]
 categories = ["rendering", "embedded", "no-std"]
 
 [dependencies]
-embedded-graphics = "0.4"
+embedded-graphics = "0.5"
 
 font-kit = { version = "0.1", optional = true }
 euclid = { version = "0.19", optional = true }
 image = { version = "0.20", optional = true, default-features = false, features = ["png_codec"] }
 
 [features]
-default-features = []
+default = []
 exe = ["font-kit", "euclid", "image"]


### PR DESCRIPTION
Works well with 0.5 which is the current latest (non-alpha) release.