### PR TITLE
Make options run-time configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ euclid = { version = "0.19", optional = true }
 image = { version = "0.20", optional = true, default-features = false, features = ["png_codec"] }
 embedded-graphics-simulator = { version = "0.3.0", optional = true }
 
+[dev-dependencies]
+pico-args = { version = "0.4.2" }
+
 [features]
 default = []
 exe = ["font-kit", "euclid", "image"]


### PR DESCRIPTION
This should facilitate playing around with styles and help out in cases where the window would overflow the display.

I pirated the debugger for https://github.com/sirhcel/embedded-vintage-fonts. Thanks for this great tool! I made these things run-time configurable and the UI scale factor helped me on a display where the scaling did not work out as expected and the window overflowed the complete display.